### PR TITLE
run_vim.sh: use bash for empty arg and handle any executable

### DIFF
--- a/scripts/run_vim.sh
+++ b/scripts/run_vim.sh
@@ -3,9 +3,11 @@
 BIN=$1
 shift
 
-if [ "$BIN" == "bash" ]; then
+if [ "$BIN" == "bash" ] || [ -z "$BIN" ]; then
   exec /bin/bash
-  exit $?
+fi
+if [ -n "$(/usr/bin/which "$BIN")" ]; then
+  exec "$BIN" "$@"
 fi
 
 # Set default vimrc to a visible file


### PR DESCRIPTION
- The "exit $?" after "exec" is not necessary: it never gets executed.
- When passing in "install_vim" it should execute it.  This uses
  `which` from busybox, which seems to look up programs only.
