### PR TITLE
run_vim.sh: exec everything that's not in /vim-build/bin

### DIFF
--- a/scripts/run_vim.sh
+++ b/scripts/run_vim.sh
@@ -6,7 +6,7 @@ shift
 if [ "$BIN" == "bash" ] || [ -z "$BIN" ]; then
   exec /bin/bash
 fi
-if [ -n "$(/usr/bin/which "$BIN")" ]; then
+if ! [ -x "/vim-build/bin/$BIN" ]; then
   exec "$BIN" "$@"
 fi
 


### PR DESCRIPTION
This fixes `nvim` being executed from `/usr/local/bin`, although it is
installed/linked in `/vim-build/bin`.

Ref: https://github.com/tweekmonster/vim-testbed/pull/9#issuecomment-252396530
