### PR TITLE
run_vim.sh: use explicit HOME in /tmp

### DIFF
--- a/scripts/run_vim.sh
+++ b/scripts/run_vim.sh
@@ -21,4 +21,5 @@ done
 
 # Run as the vimtest user.  This is not really for security.  It is for running
 # Vim as a user that's unable to write to your volume.
-exec su -l vimtest -c "cd /testplugin && /vim-build/bin/$BIN $ARGS"
+cd /testplugin || exit
+exec su -l vimtest -c "env HOME=/tmp/vimtestbed-home /vim-build/bin/$BIN $ARGS"


### PR DESCRIPTION
This is required for Neovim to suppress errors that it cannot write to
~/.local etc.
