### PR TITLE
Revert "run_vim.sh: use explicit HOME in /tmp (#11)"

### DIFF
--- a/scripts/run_vim.sh
+++ b/scripts/run_vim.sh
@@ -21,5 +21,4 @@ done
 
 # Run as the vimtest user.  This is not really for security.  It is for running
 # Vim as a user that's unable to write to your volume.
-cd /testplugin || exit
-exec su -l vimtest -c "env HOME=/tmp/vimtestbed-home /vim-build/bin/$BIN $ARGS"
+exec su -l vimtest -c "cd /testplugin && /vim-build/bin/$BIN $ARGS"


### PR DESCRIPTION
This reverts commit e1bc2a1526805bf64572447caa606918e2b624bb.

This could be made working with the following, but then the vimrc from
the HOME gets not picked up probably etc, so there needs to be another
fix for the Neovim case:

```
exec su -l vimtest -c "env HOME=/tmp/vimtestbed-home \
  sh -c 'cd /testplugin && /vim-build/bin/$BIN $ARGS'"
```

Fixes https://github.com/tweekmonster/vim-testbed/pull/11/files#r82528988.
