### PR TITLE
install_vim: "apk add ruby" for -ruby

### DIFF
--- a/scripts/install_vim.sh
+++ b/scripts/install_vim.sh
@@ -38,7 +38,7 @@ build() {
 
   if [ $RUBY -eq 1 ]; then
     CONFIG_ARGS="$CONFIG_ARGS --enable-rubyinterp"
-    apk add ruby-dev
+    apk add ruby-dev ruby
   fi
 
   if [ $LUA -eq 1 ]; then


### PR DESCRIPTION
Otherwise at least vim master does not build against it:

> checking --enable-rubyinterp argument... yes
> checking --with-ruby-command argument... defaulting to ruby
> checking for ruby... no