### PR TITLE
Remove bash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,6 @@
 FROM alpine:3.5
 
-RUN apk --update add bash \
-  && rm -rf /var/cache/apk/* /tmp/* /var/tmp/*
-
-RUN adduser -h /home -s /bin/bash -D -u 8465 vimtest
+RUN adduser -h /home -s /bin/sh -D -u 8465 vimtest
 
 RUN mkdir -p /vim /vim-build/bin /plugins
 RUN chown vimtest:vimtest /home /plugins

--- a/example/Makefile
+++ b/example/Makefile
@@ -15,5 +15,17 @@ test: test-setup
 	for vim in $$vims; do \
 	  $(DOCKER) $$vim '+Vader! test/*'; \
 	done
+	out=$$(docker run --rm "$(IMAGE)" /vim-build/bin/argecho "arg1" "arg 2"); \
+	for line in "PWD=/" "Running as: root" "Arguments:" "arg1" "arg 2"; do \
+	  if ! echo "$$out" | grep -qFx -e "$$line"; then \
+	    echo "Line not found: $$line"; echo "$$out"; exit 1; \
+	  fi \
+	done
+	out=$$(docker run --rm "$(IMAGE)" argecho "arg1" "arg 2"); \
+	for line in "Running as: vimtest" "PWD=/testplugin" "Arguments:" "-u" "/home/vimrc" "-i" "NONE" "arg1" "arg 2"; do \
+	  if ! echo "$$out" | grep -qFx -e "$$line"; then \
+	    echo "Line not found: $$line"; echo "$$out"; exit 1; \
+	  fi \
+	done
 
 .PHONY: test-setup test

--- a/scripts/argecho.sh
+++ b/scripts/argecho.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 echo "Running as: $(whoami)"
 

--- a/scripts/argecho.sh
+++ b/scripts/argecho.sh
@@ -9,6 +9,6 @@ env
 echo
 echo "Arguments:"
 while [ $# -gt 0 ]; do
-  echo $1
+  echo "$1"
   shift
 done

--- a/scripts/install_vim.sh
+++ b/scripts/install_vim.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 set -e
 
@@ -19,6 +19,8 @@ init_vars() {
 build() {
   [ -z $NAME ] && NAME="vim-${TAG}"
   [ -z $TAG ] && bail "-tag is required"
+
+  apk add ncurses
 
   VIM_NAME="vim_${TAG}_py${PYTHON}_rb${RUBY}_lua${LUA}"
   VIM_PATH="/vim-build/$VIM_NAME"

--- a/scripts/run_vim.sh
+++ b/scripts/run_vim.sh
@@ -1,10 +1,10 @@
-#!/bin/bash
+#!/bin/sh
 
 BIN=$1
 shift
 
-if [ "$BIN" == "bash" ] || [ -z "$BIN" ]; then
-  exec /bin/bash
+if [ "$BIN" = "sh" ] || [ -z "$BIN" ]; then
+  exec /bin/sh
 fi
 if ! [ -x "/vim-build/bin/$BIN" ]; then
   exec "$BIN" "$@"


### PR DESCRIPTION
This requires to install ncurses explicitly, which was installed as a
dep for bash before, and Vim requires it.

Ref: https://github.com/tweekmonster/vim-testbed/issues/20#issuecomment-289196080