### PR TITLE
Provide an image with default Vims (including Neovim)

### DIFF
--- a/Dockerfile.default
+++ b/Dockerfile.default
@@ -1,0 +1,16 @@
+# A set of default Vims, including the latest Neovim release.
+#
+# This is available online at https://hub.docker.com/r/testbed/vim-default/.
+FROM testbed/vim
+
+# Currently tested versions:
+#  - v7.3.429 (Ubuntu Precise, 12.04LTS; same as on Travis currently)
+#  - v7.4.052 (Ubuntu Trusty, 14.04LTS)
+#  - v7.4.1689 (Ubuntu Xenial, 16.04LTS)
+#  - v8.1.0000 (Stable release according to Windows download at
+#               http://www.vim.org/download.php)
+RUN install_vim -tag v7.3.429 -name vim73 -py -build \
+                -tag v7.4.052 -name vim74-trusty -build \
+                -tag v7.4.1689 -name vim74-xenial -build \
+                -tag v8.1.0000 -name vim -py2 -py3 -build \
+                -tag neovim:v0.3.1 -name nvim -py2 -py3 -build

--- a/Dockerfile.latest
+++ b/Dockerfile.latest
@@ -1,0 +1,10 @@
+# The latest Vim and Neovim releases.
+#
+# The Vim release (tag) is based on the Windows release at
+# http://www.vim.org/download.php (assuming this to be considered stable).
+#
+# This is available online at https://hub.docker.com/r/testbed/vim-latest/.
+FROM testbed/vim
+
+RUN install_vim -tag v8.1.0000 -name vim -py3 -build \
+                -tag neovim:v0.3.1 -py2 -py3 -build

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 
 DOCKER_REPO_BASE:=testbed/vim
 DOCKER_REPO_VIMS_DEFAULT:=testbed/vim-default
+DOCKER_REPO_VIMS_LATEST:=testbed/vim-latest
 
 TAG:=11
 
@@ -18,6 +19,11 @@ push_default:
 update_latest:
 	docker tag testbed/vim:$(TAG) testbed/vim:latest
 	docker push testbed/vim:latest
+
+build_latest:
+	docker build -f Dockerfile.latest -t $(DOCKER_REPO_VIMS_LATEST) .
+push_latest:
+	docker push $(DOCKER_REPO_VIMS_LATEST)
 
 # test: build the base image and example image on top, running tests therein.
 DOCKER_BASE_IMAGE:=vim-testbed-base

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,19 @@
 .PHONY: build push test
 
+DOCKER_REPO_BASE:=testbed/vim
+DOCKER_REPO_VIMS_DEFAULT:=testbed/vim-default
+
 TAG:=11
 
 build:
-	docker build -t testbed/vim:$(TAG) .
-
+	docker build -t $(DOCKER_REPO_BASE):$(TAG) .
 push:
-	docker push testbed/vim:$(TAG)
+	docker push $(DOCKER_REPO_BASE):$(TAG)
+
+build_default:
+	docker build -f Dockerfile.default -t $(DOCKER_REPO_VIMS_DEFAULT) .
+push_default:
+	docker push $(DOCKER_REPO_VIMS_DEFAULT)
 
 update_latest:
 	docker tag testbed/vim:$(TAG) testbed/vim:latest


### PR DESCRIPTION
Fixes https://github.com/tweekmonster/vim-testbed/issues/27.

TODO:
- [ ] no tags being used, just latest for now.  Do we want them?
- [ ] automatic builds for this (to update the master versions) would be nice to have