### PR TITLE
scripts/run_vim.sh: fix handling of args

### DIFF
--- a/scripts/run_vim.sh
+++ b/scripts/run_vim.sh
@@ -13,12 +13,6 @@ fi
 # Set default vimrc to a visible file
 ARGS="-u /home/vimtest/vimrc -i NONE"
 
-# So we can pass the arguments to Vim as it was passed to this script
-while [ $# -gt 0 ]; do
-  ARGS="$ARGS \"$1\""
-  shift
-done
-
 # Run as the vimtest user.  This is not really for security.  It is for running
 # Vim as a user that's unable to write to your volume.
-exec su -l vimtest -c "cd /testplugin && /vim-build/bin/$BIN $ARGS"
+exec su -l vimtest -c "cd /testplugin && /vim-build/bin/$BIN $ARGS $*"


### PR DESCRIPTION
This allows for `docker run … vim-master foo b\\ar` to work as expected
(opening 'foo' and 'b\ar').