### PR TITLE
Revert "install_vim.sh: Neovim: install ruby-json (#51)"

### DIFF
--- a/scripts/install_vim.sh
+++ b/scripts/install_vim.sh
@@ -99,7 +99,6 @@ EOF
       CONFIG_ARGS="$CONFIG_ARGS --enable-rubyinterp"
     else
       apk add --virtual vim-build ruby-rdoc ruby-irb
-      apk add ruby-json
       gem install neovim
     fi
   fi


### PR DESCRIPTION
This reverts commit e200627beda492fa08f426e0cfff02efc392adce.

Version 0.6.1 of the neovim gem should have this fixed.

Ref: https://github.com/alexgenco/neovim-ruby/issues/46#issuecomment-343780460