### PR TITLE
example/Makefile: use docker run -it

### DIFF
--- a/example/Makefile
+++ b/example/Makefile
@@ -7,7 +7,7 @@ WRITABLE_HOME:=$(shell tmpdir=$$(mktemp -d --dry-run); \
 	cd $(CURDIR)/test; \
 	cp -a vimrc *.vader $${tmpdir}/; \
 	echo $${tmpdir})
-DOCKER = docker run -a stderr --rm \
+DOCKER = docker run -it --rm \
 	-v $(CURDIR):/testplugin \
 	-v $(WRITABLE_HOME):/home/vimtest \
 	-v $(CURDIR)/$(PLUGINS):/home/vimtest/plugins "$(IMAGE)"


### PR DESCRIPTION
This helps with displaying errors from hanging Vim, e.g. due to unknown
functions with too old Vim.