### PR TITLE
Support Neovim 0.8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-TAG:=23
+TAG:=24
 
 build:
 	docker build -t testbed/vim:$(TAG) .

--- a/example/Dockerfile
+++ b/example/Dockerfile
@@ -7,7 +7,7 @@ RUN install_vim -tag v7.1 -name vim71 -prebuild_script 'echo "#define FEAT_PROFI
                 -tag v7.3.429 -name vim73 -py -build \
                 -tag v7.4.052 -name vim74-trusty -py3 -build \
                 -tag master -py2 -py3 -ruby -lua -build \
-                -tag neovim:v0.2.0 -py2 -py3 -ruby -build \
+                -tag neovim:v0.6.1 -py2 -py3 -ruby -build \
                 -tag neovim:master -py2 -py3 -ruby -build
 
 # make is installed still.

--- a/example/Makefile
+++ b/example/Makefile
@@ -44,7 +44,7 @@ test: test_vims_basic_test
 test: test_vim71_with_profiling_enabled
 test:
 	set -ex; \
-	for vim in "neovim-master --headless" vim-master; do \
+	for vim in "neovim-v0.6.1 --headless" vim-master; do \
 	  $(DOCKER) $${vim} -u NONE \
 	    "+py  import sys; open('/home/vimtest/py2', 'w').write(str(sys.version_info[0]))" \
 	    '+q'; \
@@ -77,8 +77,8 @@ test:
 	  fi; \
 	  $(RM) $(WRITABLE_HOME)/lua; \
 	done; \
-	neovim_tag_version=$$(docker run --rm "$(IMAGE)" neovim-v0.2.0 -u NONE --version | grep '^NVIM'); \
-	if [ "$$neovim_tag_version" != 'NVIM v0.2.0' ]; then \
+	neovim_tag_version=$$(docker run --rm "$(IMAGE)" neovim-v0.6.1 -u NONE --version | grep '^NVIM'); \
+	if [ "$$neovim_tag_version" != 'NVIM v0.6.1' ]; then \
 	  echo "Unexpected version for Neovim tag: $$neovim_tag_version" >&2; \
 	  exit 1; \
 	fi; \

--- a/scripts/install_vim.sh
+++ b/scripts/install_vim.sh
@@ -243,10 +243,11 @@ build() {
     DEPS_CMAKE_FLAGS="-DUSE_BUNDLED=OFF"
 
     # Use bundled treesitter (not available on Alpine yet).
-    if grep -iq 'USE_BUNDLED_TS_PARSERS' third-party/CMakeLists.txt; then
+    # NOTE: third-party was renamed to cmake.deps in 0.8.
+    if [ -e cmake.deps ] || grep -iq 'USE_BUNDLED_TS_PARSERS' cmake.deps/CMakeLists.txt; then
       DEPS_CMAKE_FLAGS="$DEPS_CMAKE_FLAGS -DUSE_BUNDLED_TS_PARSERS=ON"
     fi
-    if grep -iq 'USE_BUNDLED_TS' third-party/CMakeLists.txt; then
+    if [ -e cmake.deps ] || grep -iq 'USE_BUNDLED_TS' third-party/CMakeLists.txt; then
       DEPS_CMAKE_FLAGS="$DEPS_CMAKE_FLAGS -DUSE_BUNDLED_TS=ON"
     fi
 


### PR DESCRIPTION
Fixes https://github.com/Vimjas/vim-testbed/issues/82.

ref: https://github.com/neovim/neovim/commit/e23c5fda0a3fe385af615372c474d4dad3b74464#r87354015

Python 2 support was removed in Neovim 0.7: https://github.com/neovim/neovim/commit/baec0d315

TODO:

- [x] https://github.com/Vimjas/vim-testbed/pull/85
- [x] https://github.com/Vimjas/vim-testbed/pull/86